### PR TITLE
indicate group and member name

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -49,17 +49,17 @@
         text-decoration: none;
         a {
           text-decoration: none;
-        }
-          &__group-name{
+          .group-name{
             font-size: 15px;
             margin-bottom: 5px;
             color: #ffffff;
           }
-          &__group-message{
+          .group-message{
             font-size: 11px;
             color: #ffffff;
             text-decoration: none;
           }
+        }
       }
     }
    }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     group = Group.find(params[:id])
     if group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,16 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,11 +2,13 @@
   .wrapper__chat-main__group-info
     .wrapper__chat-main__group-info__left-box
       .wrapper__chat-main__group-info__left-box__group-name
-        test
+        = @group.name
       .wrapper__chat-main__group-info__left-box__member-name
-        membername
+        Member :
+        - @group.users.each do |user|
+          = user.name
     .wrapper__chat-main__group-info__right-box
-      = link_to "#", class: "wrapper__chat-main__group-info__right-box__edit-btn" do
+      = link_to edit_group_path(@group), class: "wrapper__chat-main__group-info__right-box__edit-btn" do
         Edit
 
   .wrapper__chat-main__message-list

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -9,10 +9,10 @@
           = icon('fa', 'edit')
   
   .wrapper__side-bar__group-list
-    .wrapper__side-bar__group-list__groups
-      -current_user.groups.each do |group|
-        = link_to '#' do
-          .wrapper__side-bar__group-list__groups__group-name
+    - current_user.groups.each do |group|
+      .wrapper__side-bar__group-list__groups
+        = link_to group_messages_path(group) do
+          .group-name
             = group.name
-          .wrapper__side-bar__group-list__groups__group-message
-            まだメッセージがありません
+          .group-message
+            = group.show_last_message


### PR DESCRIPTION
#What
サイドバーのメンバーリストとメイン画面のヘッダーの表示を実装。
サイドバーにログインユーザーの加入するグループ名一覧を表示。
メイン画面のヘッダーに現在選択しているグループ名とメンバーのリストを表示

#Why
サイドバーとメイン画面の実装をする事で、グループとメンバーとメッセージの関係性を確認する。
hamlとScssの使い方も学ぶ。